### PR TITLE
Build fixes

### DIFF
--- a/backends/libpurple/CMakeLists.txt
+++ b/backends/libpurple/CMakeLists.txt
@@ -3,14 +3,14 @@ FILE(GLOB SRC *.cpp)
 
 ADD_EXECUTABLE(spectrum2_libpurple_backend ${SRC})
 
-if(CMAKE_COMPILER_IS_GNUCXX)
+if(MSVC)
+target_link_libraries(spectrum2_libpurple_backend sqlite3 ${PURPLE_LIBRARY} ${GLIB2_LIBRARIES} ${LIBXML2_LIBRARIES} ${EVENT_LIBRARIES} transport-plugin ${PROTOBUF_LIBRARY})
+else()
 	if (NOT WIN32)
 	target_link_libraries(spectrum2_libpurple_backend ${PURPLE_LIBRARY} ${GLIB2_LIBRARIES} ${EVENT_LIBRARIES} transport-plugin pthread)
 	else()
 	target_link_libraries(spectrum2_libpurple_backend ${PURPLE_LIBRARY} ${GLIB2_LIBRARIES} ${EVENT_LIBRARIES} transport-plugin)
 	endif()
-else()
-target_link_libraries(spectrum2_libpurple_backend sqlite3 ${PURPLE_LIBRARY} ${GLIB2_LIBRARIES} ${LIBXML2_LIBRARIES} ${EVENT_LIBRARIES} transport-plugin ${PROTOBUF_LIBRARY})
 endif()
 
 INSTALL(TARGETS spectrum2_libpurple_backend RUNTIME DESTINATION bin)

--- a/spectrum/src/CMakeLists.txt
+++ b/spectrum/src/CMakeLists.txt
@@ -25,6 +25,11 @@ else ()
 target_link_libraries(spectrum2 transport spectrum2-xmpp-frontend spectrum2-slack-frontend ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES} ${PROTOBUF_LIBRARY})
 endif()
 
+if (NOT MSVC)
+# export all symbols (used for loading frontends)
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,-export-dynamic")
+endif()
+
 INSTALL(TARGETS spectrum2 RUNTIME DESTINATION bin)
 
 INSTALL(FILES

--- a/spectrum_manager/src/CMakeLists.txt
+++ b/spectrum_manager/src/CMakeLists.txt
@@ -8,8 +8,8 @@ SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/../../include/transport/
 
 target_link_libraries(spectrum2_manager transport ${SWIFTEN_LIBRARY} ${PROTOBUF_LIBRARIES})
 
-if (CMAKE_COMPILER_IS_GNUCXX)
 add_definitions(-DMG_ENABLE_SSL)
+if (CMAKE_COMPILER_IS_GNUCXX)
 target_link_libraries(spectrum2_manager ${OPENSSL_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Fixed some build and linker issues on FreeBSD.

The linker flag "-Wl,-export-dynamic" is needed to add all symbols to the symbol table of spectrum2. Otherwise it won't find the xmpp frontend symbols in itself.