### PR TITLE
Libpurple: Add service.verify_certs option to enable certificate verification

### DIFF
--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -160,7 +160,13 @@ static void * requestInput(const char *title, const char *primary,const char *se
 static void *requestAction(const char *title, const char *primary, const char *secondary, int default_action, PurpleAccount *account, const char *who,PurpleConversation *conv, void *user_data, size_t action_count, va_list actions){
 	std::string t(title ? title : "NULL");
 	if (t == "SSL Certificate Verification") {
-		LOG4CXX_INFO(logger,  "accepting SSL certificate");
+		if (CONFIG_BOOL_DEFAULTED(config, "service.verify_certs", false)) {
+			LOG4CXX_INFO(logger,  "rejecting SSL certificate");
+			va_arg(actions, char *);
+			va_arg(actions, GCallback);
+		} else {
+			LOG4CXX_INFO(logger,  "accepting SSL certificate");
+		}
 		va_arg(actions, char *);
 		((PurpleRequestActionCb) va_arg(actions, GCallback)) (user_data, 2);
 	}
@@ -176,6 +182,10 @@ static void *requestAction(const char *title, const char *primary, const char *s
 			std::string headerString(title);
 			LOG4CXX_INFO(logger,  "header string: " << headerString);
 			if (headerString == "SSL Certificate Verification") {
+				if (CONFIG_BOOL_DEFAULTED(config, "service.verify_certs", false)) {
+					va_arg(actions, char *);
+					va_arg(actions, GCallback);
+				}
 				va_arg(actions, char *);
 				((PurpleRequestActionCb) va_arg(actions, GCallback)) (user_data, 2);
 			}


### PR DESCRIPTION
I have implemented the option service.verify_certs to enable certification verification for libpurple connections. This commit does not change the default behavior, however I would strongly opt for changing the default behavior.
I have tested the patch on top of a vanilla 2.0.3 version and it is currently running on my production server. I hope it will be included in the next version :)

For reference I have some logs of my testcases:

Old behavior without service.verify_certs set in a simulated MITM scenario:
```
24814: 2016-03-10 23:14:46,003 INFO  libpurple: nss:CERT 2. CN=GeoTrust Global CA,O=GeoTrust Inc.,C=US [Certificate Authority]:
24814: 2016-03-10 23:14:46,003 INFO  libpurple: nss:  ERROR -8172: SEC_ERROR_UNTRUSTED_ISSUER
24814: 2016-03-10 23:14:46,003 INFO  backend: accepting SSL certificate
24814: 2016-03-10 23:14:46,003 INFO  libpurple: certificate/x509/tls_cached:User ACCEPTED cert
```

With service.verify_certs=1 in a simulated MITM scenario:
```
24800: 2016-03-10 23:14:12,519 INFO  libpurple: nss:CERT 2. CN=GeoTrust Global CA,O=GeoTrust Inc.,C=US [Certificate Authority]:
24800: 2016-03-10 23:14:12,519 INFO  libpurple: nss:  ERROR -8172: SEC_ERROR_UNTRUSTED_ISSUER
24800: 2016-03-10 23:14:12,519 INFO  backend: rejecting SSL certificate
24800: 2016-03-10 23:14:12,519 INFO  libpurple: certificate/x509/tls_cached:User REJECTED cert
24800: 2016-03-10 23:14:12,519 INFO  libpurple: certificate:Failed to verify certificate for jabber.Y.de
24800: 2016-03-10 23:14:12,519 INFO  libpurple: connection:Connection error on 0x1ab8160 (reason: 15 description: SSL peer presented an invalid certificate)
24800: 2016-03-10 23:14:12,520 INFO  libpurple: account:Disconnecting account Z@jabber.Y.de (0x1a952b0)
24800: 2016-03-10 23:14:12,520 INFO  libpurple: connection:Disconnecting connection 0x1ab8160
24800: 2016-03-10 23:14:12,520 INFO  libpurple: connection:Destroying connection 0x1ab8160
24800: 2016-03-10 23:14:12,534 ERROR backend: g_log purple_account_disconnect: assertion '!purple_account_is_disconnected(account)' failed
24800: 2016-03-10 23:14:12,534 INFO  libpurple: account:Destroying account 0x1a952b0
24800: 2016-03-10 23:14:18,019 INFO  libpurple: util:Writing file accounts.xml to directory /var/lib/spectrum2/jabber.xmpp.X.eu
24800: 2016-03-10 23:14:18,019 INFO  libpurple: util:Writing file /var/lib/spectrum2/jabber.xmpp.X.eu/accounts.xml
24800: 2016-03-10 23:14:25,209 INFO  backend: Exiting...
```
```
2016-03-10 23:14:12,520 INFO  User: lxp@X.eu: Disconnected from legacy network with error SSL peer presented an invalid certificate
2016-03-10 23:14:12,520 INFO  Component.RAW: RAW DATA OUT <message from="jabber.xmpp.X.eu" to="lxp@X.eu" type="chat"><body>SSL peer presented an invalid certificate</body><spectrumerror error="15" xmlns="http://spectrum.im/error">CONNECTION_ERROR_NETWORK_ERROR</spectrumerror></message>
2016-03-10 23:14:12,534 INFO  UserManager: lxp@X.eu: Disconnecting user
2016-03-10 23:14:12,534 INFO  NetworkPluginServer: Backend 24800 will die, because the last user disconnected
2016-03-10 23:14:12,534 INFO  User: lxp@X.eu: Destroying
```
As you can see the user gets notified with the following message:
```
(23:14:14) jabber.xmpp.X.eu: SSL peer presented an invalid certificate
```

Non-attack scenario with service.verify_certs=1 and purple.cacerts_dir correctly setup:
```
25595: 2016-03-10 23:24:49,750 INFO  libpurple: nss/x509:Exporting certificate to /var/lib/spectrum2/jabber.xmpp.X.eu/certificates/x509/tls_peers/jabber.Y.de
25595: 2016-03-10 23:24:49,751 INFO  libpurple: util:Writing file /var/lib/spectrum2/jabber.xmpp.X.eu/certificates/x509/tls_peers/jabber.Y.de
25595: 2016-03-10 23:24:49,761 INFO  libpurple: nss:Trusting CN=jabber.Y.de,OU=Domain Control Validated - RapidSSL(R),OU=See www.rapidssl.com/resources/cps (c)15,OU=GT
25595: 2016-03-10 23:24:49,761 INFO  libpurple: certificate:Successfully verified certificate for jabber.Y.de
```

Note: The commit message wrongly calls the option purple.verify_certs, sorry about that.