### PR TITLE
Improve debian systemd service file.

### DIFF
--- a/packaging/debian/debian/spectrum2.service
+++ b/packaging/debian/debian/spectrum2.service
@@ -1,13 +1,21 @@
 [Unit]
-Description=spectrum2
+Description=An open source instant messaging transport
+Documentation=http://spectrum.im/documentation/
 After=network.target
 
 [Service]
 Type=forking
+
+User=spectrum2
+
+RestartSec=5
+Restart=on-failure
+
 ExecStart=/usr/bin/spectrum2_manager start
-TimeoutStopSec=3
 ExecStop=/usr/bin/spectrum2_manager stop
 ExecReload=/usr/bin/spectrum2_manager restart
 
+RuntimeDirectory=spectrum2
+
 [Install]
-Alias=spectrum2
+WantedBy=multi-user.target


### PR DESCRIPTION
* better description and documentation
* use spectrum2 dedicated user
* restart on failure, without spamming other servers
* no need for a short TimeoutStopSec: spectrum2 supposedly correctly shuts down
* no need for Alias: the current filename is already OK
* add WantedBy=multi-user.target for install